### PR TITLE
Add "/lost+found" to default ignore locations

### DIFF
--- a/sysclean.pl
+++ b/sysclean.pl
@@ -96,6 +96,7 @@ sub init_ignored
 	$self->{ignored} = {
 		'/dev' => 1,
 		'/home' => 1,
+		'/lost+found' => 1,
 		'/root' => 1,
 		'/tmp' => 1,
 		'/usr/local' => 1, # remove ?


### PR DESCRIPTION
Salut,
I propose to ignore the "/lost+found" directory by default.
I've added it in the middle to respect the alphabetical order you use.

Another (unrelated) suggestion, you could add `sysclean | xargs rm -rfv` to the examples, with some warning of course. If you want a pull request tell me.

PS: cimer Albert pour le soft, j'en avais du déchet ! ^^